### PR TITLE
chore(vscode): configure default tab behaviour in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "editor.tabSize": 2,
+  "editor.insertSpaces": true,
+  "editor.detectIndentation": false,
+  "[json]": {
+    "editor.tabSize": 2,
+    "editor.insertSpaces": true
+  }
+}


### PR DESCRIPTION
* Set tab size to 2 for default and JSON editoers
* Set tabs to use spaces instead of tabs for default and JSON editors
* Prevent vscode from overriding settings based on existing formatting